### PR TITLE
Disable the plugin if either xclip or wmctrl is unavailable.

### DIFF
--- a/ftplugin/matlab_behave.vim
+++ b/ftplugin/matlab_behave.vim
@@ -4,6 +4,10 @@
 "   See readme file shipped with plugin
 " Author: E. Branlard (lastname at gmail dot com)
 
+" Do not enable this plugin if xclip or wmctrl is unavailable.
+if !executable('xclip') || !executable('wmctrl')
+    finish
+endif
 
 " --------------------------------------------------------------------------------
 " --- Cell title in bold 


### PR DESCRIPTION
Sometimes plugins can be carried across different platforms. Disable it when it's not actually supported.
