### PR TITLE
Fix MatRunExtern function to set window title correctly

### DIFF
--- a/ftplugin/matlab_behave.vim
+++ b/ftplugin/matlab_behave.vim
@@ -118,9 +118,9 @@ endfunction
 """ Run current script in a new matlab session
 function! MatRunExtern()
     if g:matlab_behave_software == "matlab"
-        call system("$TERM -e ".g:matlab_behave_software." ".g:matlab_behave_software_param." -r ".shellescape('run '.expand("%:p"))."&")
+        call system("$TERM -T '".g:matlab_behave_window_name."' -e ".g:matlab_behave_software." ".g:matlab_behave_software_param." -r ".shellescape('run '.expand("%:p"))."&")
     elseif g:matlab_behave_software == "octave"
-        call system("$TERM -e ".g:matlab_behave_software." --persist ".shellescape(expand("%:p"))."&")
+        call system("$TERM -T '".g:matlab_behave_window_name."' -e ".g:matlab_behave_software." --persist ".shellescape(expand("%:p"))."&")
     endif
 endfunction
 


### PR DESCRIPTION
Added parameter -T to set terminal window title correctly.
Once MatRunExtern is called a call of MatRun will now work correctly.

Best regards