### PR TITLE
Minor fixes and updates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,7 @@ Basic principle of the "run" functionalities
 - (Save file)
 - Copy some text (selection, cell, line, script, etc.) into the two unix clipboards. A tmp file is sometimes used.
 - Automatically switch to matlab window (GUI or terminal) using wmctrl (The window name is customized with "g:matlab_behave_window_name", if two windows have this name, this might fail).
+- Automatically focus MATLAB's prompt (In modern MATLAB versions it is done with "Ctrl-0" by default, but it can be customized with "g:matlab_behave_focus_cmd").
 - The content is paste automatically (If it fails try customizing "g:matlab_behave_paste_cmd", or use "Ctrl-V" or the middle mouse button).
 - (Depending on the command, after pasting, it will go back to vim (see Installation - matlab side) )
 

--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ Basic principle of the "run" functionalities
 - (Save file)
 - Copy some text (selection, cell, line, script, etc.) into the two unix clipboards. A tmp file is sometimes used.
 - Automatically switch to matlab window (GUI or terminal) using wmctrl (The window name is customized with "g:matlab_behave_window_name", if two windows have this name, this might fail).
-- Automatically focus MATLAB's prompt (In modern MATLAB versions it is done with "Ctrl-0" by default, but it can be customized with "g:matlab_behave_focus_cmd").
+- Automatically focus MATLAB's prompt (In modern MATLAB versions it is done with "Ctrl-0" by default. In some previuos edition it was "Escape". It can be customized with "g:matlab_behave_focus_cmd").
 - The content is paste automatically (If it fails try customizing "g:matlab_behave_paste_cmd", or use "Ctrl-V" or the middle mouse button).
 - (Depending on the command, after pasting, it will go back to vim (see Installation - matlab side) )
 

--- a/ftplugin/matlab_behave.vim
+++ b/ftplugin/matlab_behave.vim
@@ -88,6 +88,9 @@ if !exists("g:matlab_behave_paste_cmd")
         let g:matlab_behave_paste_cmd="ctrl+v"
     endif
 endif
+if !exists("g:matlab_behave_autoexec")
+    let g:matlab_behave_autoexec=0
+endif
 if !exists("g:matlab_behave_software")
     let g:matlab_behave_software="matlab"
     let g:matlab_behave_software_param="-nojvm"
@@ -180,7 +183,11 @@ endfunction
 """ Run current script 
 function! MatRun()
     normal mm
-    let @+="\n cd('".expand("%:p:h")."\'); run('".expand("%:p")."')"
+    if g:matlab_behave_autoexec
+        let @+="\n cd('".expand("%:p:h")."\'); run('".expand("%:p")."')\n"
+    else
+        let @+="\n cd('".expand("%:p:h")."\'); run('".expand("%:p")."')"
+    endif
     if has("win32") || has("win16")
     else
         call system('xclip -selection c ', @+)

--- a/ftplugin/matlab_behave.vim
+++ b/ftplugin/matlab_behave.vim
@@ -74,6 +74,13 @@ if !exists("g:matlab_behave_window_name")
         let g:matlab_behave_window_name="MATLAB R"
     endif
 endif
+if !exists("g:matlab_behave_focus_cmd")
+    if has("win32") || has("win16")
+        let g:matlab_behave_focus_cmd="^0"
+    else
+        let g:matlab_behave_focus_cmd="ctrl+0"
+    endif
+endif
 if !exists("g:matlab_behave_paste_cmd")
     if has("win32") || has("win16")
         let g:matlab_behave_paste_cmd="^v"
@@ -107,7 +114,7 @@ function! SwitchPasteCommand()
         execute "!start /b SwitchAndPasteToMatlab ".g:matlab_behave_window_name." \"".g:matlab_behave_paste_cmd."\""
     else
         " !wmctrl -a "MATLAB R";xdotool key "ctrl+v"
-        execute "!wmctrl -a \"".g:matlab_behave_window_name."\" ; xdotool key \"Escape\"   ; xdotool key \"".g:matlab_behave_paste_cmd."\""
+        execute "!wmctrl -a \"".g:matlab_behave_window_name."\" ; xdotool key \"".g:matlab_behave_focus_cmd."\"   ; xdotool key \"".g:matlab_behave_paste_cmd."\""
     endif
 endfunction
 
@@ -173,7 +180,7 @@ endfunction
 """ Run current script 
 function! MatRun()
     normal mm
-    let @+="\n cd('".expand("%:p:h")."\'); run('".expand("%:p")."')"
+    let @+="cd('".expand("%:p:h")."\'); run('".expand("%:p")."') \n"
     if has("win32") || has("win16")
     else
         call system('xclip -selection c ', @+)

--- a/ftplugin/matlab_behave.vim
+++ b/ftplugin/matlab_behave.vim
@@ -180,7 +180,7 @@ endfunction
 """ Run current script 
 function! MatRun()
     normal mm
-    let @+="cd('".expand("%:p:h")."\'); run('".expand("%:p")."') \n"
+    let @+="\n cd('".expand("%:p:h")."\'); run('".expand("%:p")."')"
     if has("win32") || has("win16")
     else
         call system('xclip -selection c ', @+)


### PR DESCRIPTION
I've noticed that the script relies on "Escape" to focus MATLAB's prompt before pasting commands. I guess this was the default key in previous versions of MATLAB but it seems to be no longer the case. I've modified the code so now it uses the key specified by `g:matlab_behave_focus_cmd` ("CTRL-0" by default). I haven't touched the lines referring to Windows, though, as I'm not familiar with the commands needed to achieve this there.
Also, I have noticed that when `MatRun()` is executed the corresponding code is pasted in the prompt, but not ran until "Enter" is manually pressed. I'm not sure if this is the intended behavior, but I have changed it so the script gets run automatically.
There may be some other things requiring and update, but so far I think this plugin still works quite well with MATLAB R2021a. Maybe I'll have a look at the line references on errors, which open a new buffer, resulting on a `E325`.